### PR TITLE
Added MIT License file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Zanichelli Editore S.p.A.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Confrontando le principali licenze per software open (e free), la licenza MIT mi è sembrata adeguata. In sostanza permette di utilizzare il software per qualunque scopo, a patto di mantenere sempre le indicazioni di copyright riportate.
Qui è riportata una descrizione più esaustiva: https://choosealicense.com/licenses/mit/

In alternativa, si possono considerare la LGPL e la Apache License. La prima (https://choosealicense.com/licenses/lgpl-3.0/) è più restrittiva, obbliga chi utilizza il software a rendere pubblico il codice; la seconda (https://choosealicense.com/licenses/apache-2.0/) è molto simile alla MIT, anche se non mi sono chiarissime le differenze, se ho ben capito aggiunge in più la necessità di rendere esplicitamente note eventuali modifiche al codice se lo si riutilizza.